### PR TITLE
chore: add example of custom rules scanning

### DIFF
--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -1,0 +1,22 @@
+name: Snyk Infrastructure as Code Custom Rules
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  snyk-iac-security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Run Snyk to check Infrastructure as Code files for issues
+        continue-on-error: false
+        uses: snyk/actions/iac@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          OCI_REGISTRY_URL: ${{ secrets.OCI_REGISTRY_URL }}
+          OCI_REGISTRY_USERNAME: ${{ secrets.OCI_REGISTRY_USERNAME }}
+          OCI_REGISTRY_PASSWORD: ${{ secrets.OCI_REGISTRY_PASSWORD }}
+        with:
+          file: custom-rules/

--- a/custom-rules/example.tf
+++ b/custom-rules/example.tf
@@ -1,0 +1,4 @@
+resource "aws_redshift_cluster" "test" {
+  cluster_identifier = "tf-redshift-cluster"
+  node_type          = "dc1.large"
+}


### PR DESCRIPTION
This PR adds a GitHub action for testing a repository against custom rules, and a fixture file to showcase the custom rules which are retrieved from an OCI registry.