### PR TITLE
chore: add example of custom rules scanning

### DIFF
--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -1,0 +1,22 @@
+name: Snyk Infrastructure as Code Custom Rules
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  snyk-iac-security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run Snyk to check Infrastructure as Code files for issues
+        continue-on-error: false
+        uses: snyk/actions/iac@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_CFG_OCI_REGISTRY_URL: ${{ secrets.OCI_REGISTRY_URL }}
+          SNYK_CFG_OCI_REGISTRY_USERNAME: ${{ secrets.OCI_REGISTRY_USERNAME }}
+          SNYK_CFG_OCI_REGISTRY_PASSWORD: ${{ secrets.OCI_REGISTRY_PASSWORD }}
+        with:
+          file: custom-rules/

--- a/custom-rules/example.tf
+++ b/custom-rules/example.tf
@@ -1,0 +1,16 @@
+resource "aws_iam_role" "new_role" {
+  name               = "new_role"
+  assume_role_policy = jsonencode({
+    Version   = "2021-11-18"
+    Statement = [
+      {
+        Action    = "sts:AssumeRole"
+        Effect    = "Allow"
+        Sid       = ""
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
+    ]
+  })
+}


### PR DESCRIPTION
This PR adds a GitHub action for testing a repository against custom rules, and a fixture file to showcase the custom rules which are retrieved from an OCI registry.